### PR TITLE
Fix Request encoding

### DIFF
--- a/src/Chrome/DevTools.purs
+++ b/src/Chrome/DevTools.purs
@@ -83,6 +83,7 @@ instance encodeRequest :: EncodeJson Request where
     ( "id" := r.id
     ~> "method" := r.method
     ~> "params" := r.params
+    ~> jsonEmptyObject
     )
 
 newtype Response = Response


### PR DESCRIPTION
Added `~> jsonEmptyObject` to the `EncodeJson Request` instance because without it the last field `params` never appears in the output